### PR TITLE
Add Ruff linting to CI workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,8 +5,23 @@ on:
   pull_request:
 
 jobs:
+  lint:
+    name: Ruff
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/astral-sh/uv:bookworm
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Python 3.12
+        run: uv python install 3.12
+      - name: Sync project environment
+        run: uv sync --python 3.12 --frozen
+      - name: Run Ruff
+        run: uv run --python 3.12 ruff check .
+
   linux:
     name: Linux / Python ${{ matrix.python-version }}
+    needs: lint
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/astral-sh/uv:bookworm
@@ -19,13 +34,12 @@ jobs:
         run: uv python install ${{ matrix.python-version }}
       - name: Sync project environment
         run: uv sync --python ${{ matrix.python-version }} --frozen
-      - name: Run Ruff
-        run: uv run --python ${{ matrix.python-version }} ruff check .
       - name: Run pytest
         run: uv run --python ${{ matrix.python-version }} pytest
 
   windows:
     name: Windows / Python ${{ matrix.python-version }}
+    needs: lint
     runs-on: windows-latest
     strategy:
       matrix:
@@ -39,9 +53,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pytest hypothesis ruff
-      - name: Run Ruff
-        run: ruff check .
+          pip install pytest hypothesis
       - name: Test with pytest
         run: |
           pip install -e .
@@ -49,6 +61,7 @@ jobs:
 
   macos:
     name: macOS / Python ${{ matrix.python-version }}
+    needs: lint
     runs-on: macos-latest
     strategy:
       matrix:
@@ -62,9 +75,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pytest hypothesis ruff
-      - name: Run Ruff
-        run: ruff check .
+          pip install pytest hypothesis
       - name: Test with pytest
         run: |
           pip install -e .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,12 @@ dev = [
 [tool.uv]
 default-groups = ["dev"]
 
+[tool.ruff]
+target-version = "py310"
+
+[tool.ruff.lint]
+select = ["E", "F"]
+
 [tool.setuptools]
 ext-modules = [
     {name = "smaz", sources = ["smazmodule.c", "smaz/smaz.c"]}

--- a/tests.py
+++ b/tests.py
@@ -72,7 +72,10 @@ def test_compress_non_bytes():
         "the end",
         "not-a-g00d-Exampl333",
         "Smaz is a simple compression library",
-        "Nothing is more difficult, and therefore more precious, than to be able to decide",
+        (
+            "Nothing is more difficult, and therefore more precious, "
+            "than to be able to decide"
+        ),
         "this is an example of what works very well with smaz",
         "1000 numbers 2000 will 10 20 30 compress very little",
         "and now a few italian sentences:",


### PR DESCRIPTION
## Summary
- add a dedicated lint job to the CI that runs Ruff with Python 3.12
- configure Ruff to use its default rule set via pyproject.toml
- wrap an overlong test fixture string so it complies with Ruff's line length rules

## Testing
- ruff check .
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68f406e35a04832896f9b38bd7055584